### PR TITLE
packaging fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,7 @@
+#!/usr/bin/env python
 from setuptools import setup
-import os
 
 from lt2opencorpora import __version__
-
-with open(os.path.join(os.path.dirname(__file__),
-                       "requirements.txt")) as req_file:
-    requirements = req_file.read().splitlines()
 
 setup(
     name='LT2OpenCorpora',
@@ -14,10 +10,34 @@ setup(
     author_email='chaplinsky.dmitry@gmail.com',
     packages=['lt2opencorpora'],
     url='https://github.com/dchaplinsky/LT2OpenCorpora',
-    description='Python script to convert ukrainian morphological dictionary '
+    description='Python script to convert Ukrainian morphological dictionary '
                 'from LanguageTool project to OpenCorpora forma',
     scripts=['bin/lt_convert.py', 'bin/lt_plot.py'],
     package_data={"lt2opencorpora": ["mapping.csv",
                                      "open_corpora_tagset.xml"]},
-    install_requires=requirements
+    license='MIT license',
+    install_requires=[
+        'blinker >= 1.3',
+        'liquer >= 0.0.4',
+        'unicodecsv >= 0.9.4',
+        'bz2file >= 0.98',
+        'requests',
+    ],
+    extras_require={
+        'plot':  ["pydot >= 1.0.2"],
+    },
+    zip_safe=False,
+    classifiers=[
+        'Intended Audience :: Developers',
+        'Intended Audience :: Science/Research',
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: Implementation :: PyPy',
+        'Topic :: Software Development :: Libraries :: Python Modules',
+        'Topic :: Scientific/Engineering :: Information Analysis',
+        'Topic :: Text Processing :: Linguistic',
+    ],
 )


### PR DESCRIPTION
Changes:

* make setup.py script executable;
* less strict install_requirements;
* zip_safe=False flag;
* license in metadata;
* trove classifiers; only Python 2.7 is supported.

The main change is `install_requires` handling: pinning package versions in `install_requires` is usually a bad practice because it means users of LT2OpenCorpora may have their packages unexpectingly downgraded or upgraded; it could also prevent a valid combination of packages from working. While == versions ensure LT2OpenCorpora itelf will work, it could break other software installed in the same environment - this is not polite. I think `install_requires` should exclude versions that are known not to work, while requirements.txt should specify versions which are known to work. 