### PR TITLE
Add support for huge dictionaries, fix bug with empty file generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ mapping.png
 tagged.main.txt
 pymorphy2-dicts/
 bugs.txt
+
+# PyCharm stuff
+.idea

--- a/bin/lt_convert.py
+++ b/bin/lt_convert.py
@@ -63,7 +63,8 @@ if __name__ == '__main__':
     if not os.path.exists(args.in_file):
         exit("In file doesn't exists or cannot be downloaded")
 
-    Dictionary(args.in_file, args.out_file, mapping=args.mapping)
+    d = Dictionary(args.in_file, mapping=args.mapping)
+    d.export_to_xml(args.out_file)
 
     if args.debug:
         logging.debug("=" * 50)

--- a/bin/lt_convert.py
+++ b/bin/lt_convert.py
@@ -7,11 +7,11 @@ import os.path
 import requests
 from tempfile import NamedTemporaryFile
 from collections import Counter
+
 sys.path.insert(0, ".")
 
 from lt2opencorpora.convert import (
     Dictionary, doubleform_signal)
-
 
 REPEATED_FORMS = Counter()
 
@@ -65,8 +65,7 @@ if __name__ == '__main__':
     if not os.path.exists(args.in_file):
         exit("In file doesn't exists or cannot be downloaded")
 
-    d = Dictionary(args.in_file, mapping=args.mapping)
-    d.export_to_xml(args.out_file)
+    Dictionary(args.in_file, args.out_file, mapping=args.mapping)
 
     if args.debug:
         logging.debug("=" * 50)

--- a/bin/lt_convert.py
+++ b/bin/lt_convert.py
@@ -7,16 +7,14 @@ import os.path
 import requests
 from tempfile import NamedTemporaryFile
 from collections import Counter
+from lt2opencorpora.convert import Dictionary, doubleform_signal
 
 sys.path.insert(0, ".")
-
-from lt2opencorpora.convert import (
-    Dictionary, doubleform_signal)
 
 REPEATED_FORMS = Counter()
 
 
-def log_doubleform(sender, tags_signature):
+def log_double_form(sender, tags_signature):
     REPEATED_FORMS.update({tags_signature: 1})
 
 
@@ -57,7 +55,7 @@ if __name__ == '__main__':
 
     if args.debug:
         logging.basicConfig(level=logging.DEBUG)
-        doubleform_signal.connect(log_doubleform)
+        doubleform_signal.connect(log_double_form)
 
     if args.in_file.startswith(("http://", "https://")):
         args.in_file = download_to_tmp(args.in_file)

--- a/bin/lt_plot.py
+++ b/bin/lt_plot.py
@@ -2,7 +2,7 @@
 import os.path
 import sys
 import pydot
-from unicodecsv import DictReader
+from csv import DictReader
 import xml.etree.ElementTree as ET
 
 sys.path.insert(0, ".")

--- a/bin/lt_plot.py
+++ b/bin/lt_plot.py
@@ -4,10 +4,9 @@ import sys
 import pydot
 from csv import DictReader
 import xml.etree.ElementTree as ET
+import lt2opencorpora
 
 sys.path.insert(0, ".")
-
-import lt2opencorpora
 
 if __name__ == '__main__':
     # TODO: argparse
@@ -32,7 +31,7 @@ if __name__ == '__main__':
 
         for tag in r:
             tag["opencorpora tags"] = (
-                tag["opencorpora tags"] or tag["name"])
+                    tag["opencorpora tags"] or tag["name"])
 
             name = "%s\n%s" % (tag["name"], tag["opencorpora tags"])
 
@@ -51,12 +50,12 @@ if __name__ == '__main__':
             nodes_by_LT[tag["name"]] = node
             nodes_by_opencorpora[tag["opencorpora tags"]] = node
 
-    for k, node in nodes_by_opencorpora.iteritems():
+    for k, node in nodes_by_opencorpora.items():
         graph.add_node(node)
 
         if node.parent and node.parent != "aux":
             graph.add_edge(pydot.Edge(node, nodes_by_LT[node.parent],
-                           color="orange"))
+                                      color="orange"))
 
         if node.ru_parent:
             graph.add_edge(

--- a/lt2opencorpora/convert.py
+++ b/lt2opencorpora/convert.py
@@ -251,12 +251,11 @@ class Lemma:
 
 
 class Dictionary:
-    def __init__(self, input_file: str, output_file: str, mapping: str) -> None:
+    def __init__(self, input_file: str, mapping: str) -> None:
         if not mapping:
             mapping = os.path.join(os.path.dirname(__file__), "mapping.csv")
 
         self.tag_set = TagSet(mapping)
-        self.output_file = output_file
 
         self.counter = 1
         self.total_xml = ''
@@ -286,7 +285,6 @@ class Dictionary:
 
             self.add_lemma(current_lemma)
         self.write_tree()
-        self.write_final()
 
     def add_lemma(self, lemma: Lemma):
         if lemma is not None:
@@ -300,10 +298,11 @@ class Dictionary:
             f.write('\n{}'.format(self.total_xml))
         self.total_xml = ''
 
-    def write_final(self):
+    @staticmethod
+    def export_to_xml(out_file: str):
         # line where to insert result.xml
         template_start = 440
-        with open(self.output_file, 'w') as of:
+        with open(out_file, 'w') as of:
             with open('template.xml') as tf:
                 counter = 0
                 for line in tf:

--- a/lt2opencorpora/convert.py
+++ b/lt2opencorpora/convert.py
@@ -50,11 +50,9 @@ class TagSet:
             for tag in r:
                 # lemma form column represents set of tags that wordform should
                 # have to be threatened as lemma.
-                tag["lemma form"] = filter(None, map(lambda x: x.strip,
-                                                     tag["lemma form"].split(",")))
+                tag["lemma form"] = filter(None, map(str.strip, tag["lemma form"].split(",")))
 
-                tag["divide by"] = filter(
-                    None, map(lambda x: x.strip, tag["divide by"].split(",")))
+                tag["divide by"] = filter(None, map(str.strip, tag["divide by"].split(",")))
 
                 # opencopropra tags column maps LT tags to OpenCorpora tags
                 # when possible
@@ -136,7 +134,7 @@ class WordForm:
                 "|:rel|:neg|:ind|:gen)+)(.*)", "pron\\3\\2\\4", tags)
         self.form, self.tags = form, tags
 
-        self.tags = list(map(lambda x: x.strip(), self.tags.split(":")))
+        self.tags = list(map(str.strip, self.tags.split(":")))
         self.is_lemma = is_lemma
 
         # tags signature is string made out of sorted list of wordform tags

--- a/lt2opencorpora/convert.py
+++ b/lt2opencorpora/convert.py
@@ -249,7 +249,7 @@ class Dictionary:
         self.tag_set = TagSet(mapping)
 
         self.counter = 1
-        self.total_xml = ''
+        self.lemmata = ET.Element("lemmata")
 
         with open_any(input_file)(input_file, "r") as fp:
             current_lemma = None
@@ -282,12 +282,16 @@ class Dictionary:
             lemma_xml = lemma.export_to_xml(self.counter)
             if lemma_xml is not None:
                 self.counter += 1
-                self.total_xml += ET.tostring(lemma_xml, encoding='unicode')
+                self.lemmata.append(lemma_xml)
 
     def write_tree(self):
+        total_xml = ET.tostring(self.lemmata, encoding='unicode')
+        # Remove to release memory
+        self.lemmata.clear()
+        # Need to remove <lemata> and </lemata>
+        total_xml = total_xml[len('<lemata>') + 1:-len('</lemata>') - 1]
         with open('temp.xml', 'a') as f:
-            f.write('\n{}'.format(self.total_xml))
-        self.total_xml = ''
+            f.write('\n{}'.format(total_xml))
 
     @staticmethod
     def export_to_xml(out_file: str):

--- a/lt2opencorpora/convert.py
+++ b/lt2opencorpora/convert.py
@@ -258,9 +258,8 @@ class Dictionary:
         self.tag_set = TagSet(mapping)
         self.output_file = output_file
 
-        self.lemmata = ET.Element("lemmata")
-        self.tree = ET.ElementTree(self.lemmata)
         self.counter = 1
+        self.total_xml = ''
 
         with open_any(input_file)(input_file, "r") as fp:
             current_lemma = None
@@ -294,14 +293,12 @@ class Dictionary:
             lemma_xml = lemma.export_to_xml(self.counter)
             if lemma_xml is not None:
                 self.counter += 1
-                self.lemmata.append(lemma_xml)
+                self.total_xml += ET.tostring(lemma_xml, encoding='unicode')
 
     def write_tree(self):
-        xml = ET.tostring(self.lemmata, encoding='unicode')
-        xml = '\n' + xml[9:-10]
         with open('temp.xml', 'a') as f:
-            f.write(xml)
-        self.lemmata.clear()
+            f.write('\n{}'.format(self.total_xml))
+        self.total_xml = ''
 
     def write_final(self):
         # line where to insert result.xml

--- a/lt2opencorpora/convert.py
+++ b/lt2opencorpora/convert.py
@@ -2,7 +2,6 @@ import re
 import sys
 import gzip
 import os.path
-from filecmp import cmp
 from typing import List, Optional, Set, Union
 import bz2
 import codecs
@@ -93,15 +92,7 @@ class TagSet:
             return len(self.groups)
 
     def sort_tags(self, tags: List[str]) -> List[str]:
-        def inner_cmp(a: str, b: str) -> bool:
-            a_group = self._get_group_no(a)
-            b_group = self._get_group_no(b)
-
-            if a_group == b_group:
-                return cmp(a, b)
-            return False
-
-        return sorted(tags, key=inner_cmp)
+        return sorted(tags, key=lambda x: (self._get_group_no(x), x))
 
     def export_to_xml(self) -> ET.Element:
         grammemes = ET.Element("grammemes")
@@ -216,7 +207,7 @@ class Lemma:
             ET.SubElement(el, "g", v=self.tag_set.lt2opencorpora[self.pos])
             tags = set(tags) - {self.pos}
 
-        # tags = self.tag_set.sort_tags(tags)
+        tags = self.tag_set.sort_tags(tags)
 
         for tag in tags:
             # For rare cases when tag in the dict is not from tagset

--- a/lt2opencorpora/convert.py
+++ b/lt2opencorpora/convert.py
@@ -4,7 +4,7 @@ import gzip
 import os.path
 from filecmp import cmp
 from typing import List, Optional, Set, Union
-import bz2file as bz2
+import bz2
 import codecs
 import logging
 import xml.etree.cElementTree as ET

--- a/lt2opencorpora/convert.py
+++ b/lt2opencorpora/convert.py
@@ -251,7 +251,7 @@ class Lemma:
 
 
 class Dictionary:
-    def __init__(self, input_file: str, output_file: str, mapping) -> None:
+    def __init__(self, input_file: str, output_file: str, mapping: str) -> None:
         if not mapping:
             mapping = os.path.join(os.path.dirname(__file__), "mapping.csv")
 
@@ -297,13 +297,10 @@ class Dictionary:
                 self.lemmata.append(lemma_xml)
 
     def write_tree(self):
-        self.tree.write('temp.xml', encoding="utf-8")
-        with open('temp.xml') as f:
-            file_content = f.read()
-            file_content = '\n' + file_content[9:-10]
-            with open('result.xml', 'a') as af:
-                af.write(file_content)
-        os.remove('{}/temp.xml'.format(os.path.abspath(os.getcwd())))
+        xml = ET.tostring(self.lemmata, encoding='unicode')
+        xml = '\n' + xml[9:-10]
+        with open('temp.xml', 'a') as f:
+            f.write(xml)
         self.lemmata.clear()
 
     def write_final(self):
@@ -315,8 +312,8 @@ class Dictionary:
                 for line in tf:
                     counter += 1
                     if counter == template_start:
-                        with open('result.xml') as rf:
+                        with open('temp.xml') as rf:
                             for result_line in rf:
                                 of.write(result_line)
                     of.write(line)
-        os.remove('{}/result.xml'.format(os.path.abspath(os.getcwd())))
+        os.remove('{}/temp.xml'.format(os.path.abspath(os.getcwd())))

--- a/lt2opencorpora/convert.py
+++ b/lt2opencorpora/convert.py
@@ -291,16 +291,11 @@ class Dictionary:
 
     @staticmethod
     def export_to_xml(out_file: str):
-        # line where to insert result.xml
-        template_start = 440
         with open(out_file, 'w') as of:
-            with open('template.xml') as tf:
-                counter = 0
-                for line in tf:
-                    counter += 1
-                    if counter == template_start:
-                        with open('temp.xml') as rf:
-                            for result_line in rf:
-                                of.write(result_line)
-                    of.write(line)
+            with open('template_start.xml') as tf:
+                of.write(tf.read())
+            with open('temp.xml') as rf:
+                for result_line in rf:
+                    of.write(result_line)
+            of.write('\n</lemmata></dictionary>')
         os.remove('{}/temp.xml'.format(os.path.abspath(os.getcwd())))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+pydot~=1.4.2
 requests~=2.26.0
 setuptools~=57.0.0
 blinker~=1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ unicodecsv==0.14.1
 bz2file==0.98
 pydot==1.2.4
 requests==2.5.1
+setuptools~=57.0.0
+six~=1.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,3 @@
-blinker==1.3
-liquer==0.0.4
-unicodecsv==0.14.1
-bz2file==0.98
-pydot==1.2.4
-requests==2.5.1
+requests~=2.26.0
 setuptools~=57.0.0
-six~=1.16.0
+blinker~=1.4

--- a/template.xml
+++ b/template.xml
@@ -1,0 +1,441 @@
+<dictionary version="0.2" revision="1">
+    <grammemes>
+        <grammeme>
+            <name>POST</name>
+            <alias>post</alias>
+            <description>частина мови</description>
+        </grammeme>
+        <grammeme parent="post">
+            <name>NOUN</name>
+            <alias>noun</alias>
+            <description>іменник</description>
+        </grammeme>
+        <grammeme parent="post">
+            <name>NPRO</name>
+            <alias>pron</alias>
+            <description>займенник</description>
+        </grammeme>
+        <grammeme parent="post">
+            <name>VERB</name>
+            <alias>verb</alias>
+            <description>дієслово</description>
+        </grammeme>
+        <grammeme parent="post">
+            <name>ADJF</name>
+            <alias>adj</alias>
+            <description>прикметник</description>
+        </grammeme>
+        <grammeme parent="post">
+            <name>PRTF</name>
+            <alias>adjp</alias>
+            <description>дієприкметник</description>
+        </grammeme>
+        <grammeme parent="post">
+            <name>ADVB</name>
+            <alias>adv</alias>
+            <description>прислівник</description>
+        </grammeme>
+        <grammeme parent="post">
+            <name>GRND</name>
+            <alias>advp</alias>
+            <description>дієприслівник</description>
+        </grammeme>
+        <grammeme parent="post">
+            <name>PREP</name>
+            <alias>prep</alias>
+            <description>прийменник</description>
+        </grammeme>
+        <grammeme parent="post">
+            <name>PRED</name>
+            <alias>predic</alias>
+            <description>присудкове слово</description>
+        </grammeme>
+        <grammeme parent="post">
+            <name>Prnt</name>
+            <alias>insert</alias>
+            <description>вставне слово</description>
+        </grammeme>
+        <grammeme parent="post">
+            <name>CONJ</name>
+            <alias>conj</alias>
+            <description>сполучник</description>
+        </grammeme>
+        <grammeme parent="post">
+            <name>PRCL</name>
+            <alias>part</alias>
+            <description>частка</description>
+        </grammeme>
+        <grammeme parent="post">
+            <name>INTJ</name>
+            <alias>excl</alias>
+            <description>вигук</description>
+        </grammeme>
+        <grammeme parent="post">
+            <name>NUMR</name>
+            <alias>numr</alias>
+            <description>числівник</description>
+        </grammeme>
+        <grammeme>
+            <name>NMbr</name>
+            <alias>nmbr</alias>
+            <description>число</description>
+        </grammeme>
+        <grammeme parent="nmbr">
+            <name>plur</name>
+            <alias>p</alias>
+            <description>множина</description>
+        </grammeme>
+        <grammeme parent="nmbr">
+            <name>sing</name>
+            <alias>s</alias>
+            <description>однина</description>
+        </grammeme>
+        <grammeme>
+            <name>GNdr</name>
+            <alias>gndr</alias>
+            <description>рід</description>
+        </grammeme>
+        <grammeme parent="gndr">
+            <name>masc</name>
+            <alias>m</alias>
+            <description>чоловічий</description>
+        </grammeme>
+        <grammeme parent="gndr">
+            <name>femn</name>
+            <alias>f</alias>
+            <description>жіночий</description>
+        </grammeme>
+        <grammeme parent="gndr">
+            <name>neut</name>
+            <alias>n</alias>
+            <description>середній</description>
+        </grammeme>
+        <grammeme>
+            <name>PErs</name>
+            <alias>PErs</alias>
+            <description>особа</description>
+        </grammeme>
+        <grammeme parent="PErs">
+            <name>1per</name>
+            <alias>1</alias>
+            <description>1-а особа</description>
+        </grammeme>
+        <grammeme parent="PErs">
+            <name>2per</name>
+            <alias>2</alias>
+            <description>2-а особа</description>
+        </grammeme>
+        <grammeme parent="PErs">
+            <name>3per</name>
+            <alias>3</alias>
+            <description>3-а особа</description>
+        </grammeme>
+        <grammeme>
+            <name>CAse</name>
+            <alias>CAse</alias>
+            <description>відмінок</description>
+        </grammeme>
+        <grammeme parent="CAse">
+            <name>nomn</name>
+            <alias>v_naz</alias>
+            <description>називний</description>
+        </grammeme>
+        <grammeme parent="CAse">
+            <name>gent</name>
+            <alias>v_rod</alias>
+            <description>родовий</description>
+        </grammeme>
+        <grammeme parent="CAse">
+            <name>datv</name>
+            <alias>v_dav</alias>
+            <description>давальний</description>
+        </grammeme>
+        <grammeme parent="CAse">
+            <name>accs</name>
+            <alias>v_zna</alias>
+            <description>знахідний</description>
+        </grammeme>
+        <grammeme parent="CAse">
+            <name>ablt</name>
+            <alias>v_oru</alias>
+            <description>орудний</description>
+        </grammeme>
+        <grammeme parent="CAse">
+            <name>loct</name>
+            <alias>v_mis</alias>
+            <description>місцевий</description>
+        </grammeme>
+        <grammeme parent="CAse">
+            <name>voct</name>
+            <alias>v_kly</alias>
+            <description>кличний</description>
+        </grammeme>
+        <grammeme>
+            <name>tantum</name>
+            <alias>tantum</alias>
+            <description>singularia/pluralia tantum</description>
+        </grammeme>
+        <grammeme parent="tantum">
+            <name>Sgtm</name>
+            <alias>np</alias>
+            <description>без множини (поки лише для невідмінюваних іменників)</description>
+        </grammeme>
+        <grammeme parent="tantum">
+            <name>Pltm</name>
+            <alias>ns</alias>
+            <description>без однини (поки лише для невідмінюваних іменників)</description>
+        </grammeme>
+        <grammeme>
+            <name>req_case</name>
+            <alias>req_case</alias>
+            <description>потребує відмінка</description>
+        </grammeme>
+        <grammeme parent="req_case">
+            <name>rv_nomn</name>
+            <alias>rv_naz</alias>
+            <description>потребує називного</description>
+        </grammeme>
+        <grammeme parent="req_case">
+            <name>rv_gent</name>
+            <alias>rv_rod</alias>
+            <description>потребує родового</description>
+        </grammeme>
+        <grammeme parent="req_case">
+            <name>rv_datv</name>
+            <alias>rv_dav</alias>
+            <description>потребує давального</description>
+        </grammeme>
+        <grammeme parent="req_case">
+            <name>rv_accs</name>
+            <alias>rv_zna</alias>
+            <description>потребує знахідного</description>
+        </grammeme>
+        <grammeme parent="req_case">
+            <name>rv_ablt</name>
+            <alias>rv_oru</alias>
+            <description>потребує орудного</description>
+        </grammeme>
+        <grammeme parent="req_case">
+            <name>rv_loct</name>
+            <alias>rv_mis</alias>
+            <description>потребує місцевого</description>
+        </grammeme>
+        <grammeme>
+            <name>TEns</name>
+            <alias>tense</alias>
+            <description>час</description>
+        </grammeme>
+        <grammeme parent="tense">
+            <name>futr</name>
+            <alias>futr</alias>
+            <description>майбутній час</description>
+        </grammeme>
+        <grammeme parent="tense">
+            <name>past</name>
+            <alias>past</alias>
+            <description>минулий час</description>
+        </grammeme>
+        <grammeme parent="tense">
+            <name>pres</name>
+            <alias>pres</alias>
+            <description>теперішній час</description>
+        </grammeme>
+        <grammeme>
+            <name>MOod</name>
+            <alias>mood</alias>
+            <description>спосіб</description>
+        </grammeme>
+        <grammeme parent="mood">
+            <name>impr</name>
+            <alias>impr</alias>
+            <description>наказовий спосіб</description>
+        </grammeme>
+        <grammeme>
+            <name>verb_type</name>
+            <alias>verb_type</alias>
+            <description>форма дієслова</description>
+        </grammeme>
+        <grammeme parent="verb_type">
+            <name>infn</name>
+            <alias>inf</alias>
+            <description>початкова форма дієслова</description>
+        </grammeme>
+        <grammeme parent="verb_type">
+            <name>Impe</name>
+            <alias>impers</alias>
+            <description>безособова форма дієслова</description>
+        </grammeme>
+        <grammeme>
+            <name>VOic</name>
+            <alias>voice</alias>
+            <description>стан</description>
+        </grammeme>
+        <grammeme parent="voice">
+            <name>actv</name>
+            <alias>actv</alias>
+            <description>активний</description>
+        </grammeme>
+        <grammeme parent="voice">
+            <name>pssv</name>
+            <alias>pasv</alias>
+            <description>пасивний</description>
+        </grammeme>
+        <grammeme>
+            <name>conj_type</name>
+            <alias>conj_type</alias>
+            <description>вид сполучника</description>
+        </grammeme>
+        <grammeme parent="conj_type">
+            <name>subord</name>
+            <alias>subord</alias>
+            <description>підрядний (сполучник)</description>
+        </grammeme>
+        <grammeme parent="conj_type">
+            <name>coord</name>
+            <alias>coord</alias>
+            <description>сурядний (сполучник)</description>
+        </grammeme>
+        <grammeme>
+            <name>ASpc</name>
+            <alias>aspc</alias>
+            <description>вид</description>
+        </grammeme>
+        <grammeme parent="aspc">
+            <name>perf</name>
+            <alias>perf</alias>
+            <description>доконане</description>
+        </grammeme>
+        <grammeme parent="aspc">
+            <name>impf</name>
+            <alias>imperf</alias>
+            <description>недоконане</description>
+        </grammeme>
+        <grammeme>
+            <name>TRns</name>
+            <alias>trns</alias>
+            <description>категорія перехідності</description>
+        </grammeme>
+        <grammeme parent="trns">
+            <name>tran</name>
+            <alias>tran</alias>
+            <description>перехідне</description>
+        </grammeme>
+        <grammeme parent="trns">
+            <name>intr</name>
+            <alias>intran</alias>
+            <description>непрехідне</description>
+        </grammeme>
+        <grammeme>
+            <name>forms</name>
+            <alias>forms</alias>
+            <description>степені порівняння</description>
+        </grammeme>
+        <grammeme parent="forms">
+            <name>compb</name>
+            <alias>compb</alias>
+            <description>базова форма</description>
+        </grammeme>
+        <grammeme parent="forms">
+            <name>COMP</name>
+            <alias>compr</alias>
+            <description>порівняльна форма</description>
+        </grammeme>
+        <grammeme parent="forms">
+            <name>Supr</name>
+            <alias>super</alias>
+            <description>найвища форма</description>
+        </grammeme>
+        <grammeme>
+            <name>ANim</name>
+            <alias>ANim</alias>
+            <description>істота/неістота</description>
+        </grammeme>
+        <grammeme parent="ANim">
+            <name>anim</name>
+            <alias>anim</alias>
+            <description>істота (людина, людиноподібна істота чи тварина)</description>
+        </grammeme>
+        <grammeme parent="ANim">
+            <name>inan</name>
+            <alias>inanim</alias>
+            <description>неістота</description>
+        </grammeme>
+        <grammeme>
+            <name>Fixd</name>
+            <alias>nv</alias>
+            <description>не відмінюється</description>
+        </grammeme>
+        <grammeme>
+            <name>Dist</name>
+            <alias>bad</alias>
+            <description>покруч</description>
+        </grammeme>
+        <grammeme>
+            <name>Refl</name>
+            <alias>rev</alias>
+            <description>зворотна форма (дієслова)</description>
+        </grammeme>
+        <grammeme>
+            <name>Arch</name>
+            <alias>rare</alias>
+            <description>рідковживане/діалектичне/застаріле</description>
+        </grammeme>
+        <grammeme>
+            <name>v-u</name>
+            <alias>v-u</alias>
+            <description>альтернативні форми на в-/у- (для правил милозвучності)</description>
+        </grammeme>
+        <grammeme>
+            <name>Abbr</name>
+            <alias>abbr</alias>
+            <description>абревіатура</description>
+        </grammeme>
+        <grammeme>
+            <name>Infr</name>
+            <alias>coll</alias>
+            <description>розмовне</description>
+        </grammeme>
+        <grammeme>
+            <name>Slng</name>
+            <alias>slang</alias>
+            <description>сленг</description>
+        </grammeme>
+        <grammeme>
+            <name>unknown</name>
+            <alias>unknown</alias>
+            <description>ще неопрацьовані слова/форми</description>
+        </grammeme>
+        <grammeme>
+            <name>pers</name>
+            <alias>pers</alias>
+            <description>особовий (займенник)</description>
+        </grammeme>
+        <grammeme>
+            <name>alt</name>
+            <alias>alt</alias>
+            <description>альтернативний правопис</description>
+        </grammeme>
+        <grammeme>
+            <name>Name</name>
+            <alias>fname</alias>
+            <description>им'я</description>
+        </grammeme>
+        <grammeme>
+            <name>Surn</name>
+            <alias>lname</alias>
+            <description>прізвіще</description>
+        </grammeme>
+        <grammeme>
+            <name>Patr</name>
+            <alias>pname</alias>
+            <description>по батькові</description>
+        </grammeme>
+        <grammeme>
+            <name>Init</name>
+            <alias>init</alias>
+            <description>Ініціали</description>
+        </grammeme>
+    </grammemes>
+    <lemmata>
+    </lemmata>
+</dictionary>

--- a/template_start.xml
+++ b/template_start.xml
@@ -437,5 +437,3 @@
         </grammeme>
     </grammemes>
     <lemmata>
-    </lemmata>
-</dictionary>


### PR DESCRIPTION
# Add support for huge dictionaries, fix bug with empty file generation

- fix problem with filter on py3 to generate opencorpora file with lemmas
- add solution for big dictionaries that can not fully be put in RAM (using template.xml)
- add typing
- remove **Py2** legacy, because of deprecation
- remove redundant dependencies
